### PR TITLE
Configure Input view animation and extension

### DIFF
--- a/app/main_screen/src/main/java/com/example/mainscreen/MainScreenContract.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/MainScreenContract.kt
@@ -19,7 +19,8 @@ class MainScreenContract {
         val sourceSelectorState: LanguageSelectorState,
         val destinationSelectorState: LanguageSelectorState,
         val isValid: Boolean,
-        val shouldShowPreTranslateImage: Boolean
+        val shouldShowPreTranslateImage: Boolean,
+        val shouldShowKeyboardButton: Boolean
     ) : ViewState
 
     data class LanguageSelectorState(

--- a/app/main_screen/src/main/java/com/example/mainscreen/MainScreenContract.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/MainScreenContract.kt
@@ -7,10 +7,10 @@ import com.example.core.arch.ViewState
 class MainScreenContract {
 
     sealed class Event : ViewEvent {
-        object RunTranslation : Event()
-        object Retry : Event()
+        data object RunTranslation : Event()
+        data object Retry : Event()
 
-        object InputViewClick: Event()
+        data object InputViewClick: Event()
     }
 
     data class State(

--- a/app/main_screen/src/main/java/com/example/mainscreen/MainScreenContract.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/MainScreenContract.kt
@@ -10,7 +10,11 @@ class MainScreenContract {
         data object RunTranslation : Event()
         data object Retry : Event()
 
-        data object InputViewClick: Event()
+        data object InputViewClick : Event()
+
+        data class PasteButtonClick(
+            val text: String?
+        ) : Event()
     }
 
     data class State(

--- a/app/main_screen/src/main/java/com/example/mainscreen/MainScreenContract.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/MainScreenContract.kt
@@ -20,7 +20,7 @@ class MainScreenContract {
         val destinationSelectorState: LanguageSelectorState,
         val isValid: Boolean,
         val shouldShowPreTranslateImage: Boolean,
-        val shouldShowSecondaryInputViews: Boolean
+        val inputViewState: InputViewState
     ) : ViewState
 
     data class LanguageSelectorState(
@@ -28,7 +28,12 @@ class MainScreenContract {
         val isError: Boolean = false,
         val isExpanded: Boolean = false,
         val onClick: () -> Unit = {}
-    )
+    ) : ViewState
+
+    data class InputViewState(
+        val shouldShowSecondaryInputViews: Boolean,
+        val isFocused: Boolean
+    ) : ViewState
 
     sealed class Effect : ViewEffect {
         // TODO: implement

--- a/app/main_screen/src/main/java/com/example/mainscreen/MainScreenContract.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/MainScreenContract.kt
@@ -9,6 +9,8 @@ class MainScreenContract {
     sealed class Event : ViewEvent {
         object RunTranslation : Event()
         object Retry : Event()
+
+        object InputViewClick: Event()
     }
 
     data class State(
@@ -16,7 +18,8 @@ class MainScreenContract {
         val translatedQuery: String,
         val sourceSelectorState: LanguageSelectorState,
         val destinationSelectorState: LanguageSelectorState,
-        val isValid: Boolean
+        val isValid: Boolean,
+        val shouldShowPreTranslateImage: Boolean
     ) : ViewState
 
     data class LanguageSelectorState(

--- a/app/main_screen/src/main/java/com/example/mainscreen/MainScreenContract.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/MainScreenContract.kt
@@ -20,7 +20,8 @@ class MainScreenContract {
         val destinationSelectorState: LanguageSelectorState,
         val isValid: Boolean,
         val shouldShowPreTranslateImage: Boolean,
-        val shouldShowKeyboardButton: Boolean
+        val shouldShowKeyboardButton: Boolean,
+        val shouldShowPlaceholder: Boolean
     ) : ViewState
 
     data class LanguageSelectorState(

--- a/app/main_screen/src/main/java/com/example/mainscreen/MainScreenContract.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/MainScreenContract.kt
@@ -20,8 +20,7 @@ class MainScreenContract {
         val destinationSelectorState: LanguageSelectorState,
         val isValid: Boolean,
         val shouldShowPreTranslateImage: Boolean,
-        val shouldShowKeyboardButton: Boolean,
-        val shouldShowPlaceholder: Boolean
+        val shouldShowSecondaryInputViews: Boolean
     ) : ViewState
 
     data class LanguageSelectorState(

--- a/app/main_screen/src/main/java/com/example/mainscreen/MainScreenViewModel.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/MainScreenViewModel.kt
@@ -25,6 +25,9 @@ class MainScreenViewModel
             is MainScreenContract.Event.InputViewClick -> {
                 processInputViewClick()
             }
+            is MainScreenContract.Event.PasteButtonClick -> {
+                processPasteButtonClick(event.text)
+            }
             else -> {
                 // TODO: implement
             }
@@ -41,6 +44,15 @@ class MainScreenViewModel
             copy(
                 shouldShowPreTranslateImage = false,
                 inputViewState = newInputViewState
+            )
+        }
+    }
+
+    private fun processPasteButtonClick(text: String?) {
+        text ?: return
+        setState {
+            copy(
+                query = text
             )
         }
     }

--- a/app/main_screen/src/main/java/com/example/mainscreen/MainScreenViewModel.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/MainScreenViewModel.kt
@@ -3,7 +3,8 @@ package com.example.mainscreen
 import com.example.core.arch.BaseViewModel
 
 class MainScreenViewModel
-    : BaseViewModel<MainScreenContract.State, MainScreenContract.Event, MainScreenContract.Effect>() {
+    :
+    BaseViewModel<MainScreenContract.State, MainScreenContract.Event, MainScreenContract.Effect>() {
     override fun setInitialState(): MainScreenContract.State {
         return MainScreenContract.State(
             query = "",
@@ -11,14 +12,13 @@ class MainScreenViewModel
             sourceSelectorState = MainScreenContract.LanguageSelectorState("RUSSIAN"),
             destinationSelectorState = MainScreenContract.LanguageSelectorState("ENGLISH"),
             isValid = true,
-            shouldShowPreTranslateImage = true, // TODO: change if tag exist
-            shouldShowKeyboardButton = true,
-            shouldShowPlaceholder = true
+            shouldShowPreTranslateImage = true,
+            shouldShowSecondaryInputViews = true
         )
     }
 
     override fun onEventReceived(event: MainScreenContract.Event) {
-        when(event) {
+        when (event) {
             is MainScreenContract.Event.InputViewClick -> {
                 processInputViewClick()
             }
@@ -32,8 +32,7 @@ class MainScreenViewModel
         setState {
             copy(
                 shouldShowPreTranslateImage = false,
-                shouldShowKeyboardButton = false,
-                shouldShowPlaceholder = false
+                shouldShowSecondaryInputViews = false
             )
         }
     }

--- a/app/main_screen/src/main/java/com/example/mainscreen/MainScreenViewModel.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/MainScreenViewModel.kt
@@ -13,7 +13,10 @@ class MainScreenViewModel
             destinationSelectorState = MainScreenContract.LanguageSelectorState("ENGLISH"),
             isValid = true,
             shouldShowPreTranslateImage = true,
-            shouldShowSecondaryInputViews = true
+            inputViewState = MainScreenContract.InputViewState(
+                shouldShowSecondaryInputViews = true,
+                isFocused = false
+            )
         )
     }
 
@@ -30,9 +33,14 @@ class MainScreenViewModel
 
     private fun processInputViewClick() {
         setState {
+            val newInputViewState = inputViewState.copy(
+                shouldShowSecondaryInputViews = false,
+                isFocused = true
+            )
+
             copy(
                 shouldShowPreTranslateImage = false,
-                shouldShowSecondaryInputViews = false
+                inputViewState = newInputViewState
             )
         }
     }

--- a/app/main_screen/src/main/java/com/example/mainscreen/MainScreenViewModel.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/MainScreenViewModel.kt
@@ -10,11 +10,27 @@ class MainScreenViewModel
             translatedQuery = "",
             sourceSelectorState = MainScreenContract.LanguageSelectorState("RUSSIAN"),
             destinationSelectorState = MainScreenContract.LanguageSelectorState("ENGLISH"),
-            isValid = true
+            isValid = true,
+            shouldShowPreTranslateImage = true
         )
     }
 
     override fun onEventReceived(event: MainScreenContract.Event) {
+        when(event) {
+            is MainScreenContract.Event.InputViewClick -> {
+                processInputViewClick()
+            }
+            else -> {
+                // TODO: implement
+            }
+        }
+    }
 
+    private fun processInputViewClick() {
+        setState {
+            copy(
+                shouldShowPreTranslateImage = false
+            )
+        }
     }
 }

--- a/app/main_screen/src/main/java/com/example/mainscreen/MainScreenViewModel.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/MainScreenViewModel.kt
@@ -11,7 +11,8 @@ class MainScreenViewModel
             sourceSelectorState = MainScreenContract.LanguageSelectorState("RUSSIAN"),
             destinationSelectorState = MainScreenContract.LanguageSelectorState("ENGLISH"),
             isValid = true,
-            shouldShowPreTranslateImage = true
+            shouldShowPreTranslateImage = true, // TODO: change if tag exist
+            shouldShowKeyboardButton = true
         )
     }
 

--- a/app/main_screen/src/main/java/com/example/mainscreen/MainScreenViewModel.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/MainScreenViewModel.kt
@@ -12,7 +12,8 @@ class MainScreenViewModel
             destinationSelectorState = MainScreenContract.LanguageSelectorState("ENGLISH"),
             isValid = true,
             shouldShowPreTranslateImage = true, // TODO: change if tag exist
-            shouldShowKeyboardButton = true
+            shouldShowKeyboardButton = true,
+            shouldShowPlaceholder = true
         )
     }
 
@@ -30,7 +31,9 @@ class MainScreenViewModel
     private fun processInputViewClick() {
         setState {
             copy(
-                shouldShowPreTranslateImage = false
+                shouldShowPreTranslateImage = false,
+                shouldShowKeyboardButton = false,
+                shouldShowPlaceholder = false
             )
         }
     }

--- a/app/main_screen/src/main/java/com/example/mainscreen/composables/InputView.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/composables/InputView.kt
@@ -52,6 +52,7 @@ fun inputViewTextStyle(
 @Composable
 fun InputView(
     isKeyboardButtonVisible: Boolean,
+    isPlaceholderVisible: Boolean,
     onClick: () -> Unit = {},
     textFieldColors: TextFieldColors = defaultTextFieldColors()
 ) {
@@ -74,11 +75,9 @@ fun InputView(
             shape = RoundedCornerShape(roundingSize, roundingSize, 0.dp, 0.dp),
             textStyle = inputViewTextStyle(),
             placeholder = {
-                Text(
-                    text = stringResource(R.string.input_view_hint),
-                    style = inputViewTextStyle(Color(0xFFA3ADB5)),
-                    modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp)
-                )
+                if (isPlaceholderVisible) {
+                    Placeholder()
+                }
             },
             interactionSource = remember { MutableInteractionSource() }
                 .also { source ->
@@ -118,6 +117,15 @@ fun InputView(
             }
         }
     }
+}
+
+@Composable
+fun Placeholder() {
+    Text(
+        text = stringResource(R.string.input_view_hint),
+        style = inputViewTextStyle(Color(0xFFA3ADB5)),
+        modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp)
+    )
 }
 
 @Composable

--- a/app/main_screen/src/main/java/com/example/mainscreen/composables/InputView.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/composables/InputView.kt
@@ -51,9 +51,9 @@ fun inputViewTextStyle(
     color = textColor
 )
 
-// TODO: configure maximum vertical expansion
 @Composable
 fun InputView(
+    isKeyboardButtonVisible: Boolean,
     onClick: () -> Unit = {},
     textFieldColors: TextFieldColors = defaultTextFieldColors()
 ) {
@@ -102,21 +102,22 @@ fun InputView(
                 }
         )
 
-        // TODO: hide on click
-        IconButton(
-            onClick = { /*TODO*/ },
-            modifier = Modifier
-                .constrainAs(keyboardButton) {
-                    centerHorizontallyTo(inputArea)
-                    bottom.linkTo(inputArea.bottom, margin = 24.5.dp)
-                }
-                .size(70.dp)
-        ) {
-            Icon(
-                painter = painterResource(R.drawable.btn_keyboard),
-                contentDescription = stringResource(R.string.language_selector_expand_more),
-                tint = Color.Unspecified
-            )
+        if (isKeyboardButtonVisible) {
+            IconButton(
+                onClick = { onClick() },
+                modifier = Modifier
+                    .constrainAs(keyboardButton) {
+                        centerHorizontallyTo(inputArea)
+                        bottom.linkTo(inputArea.bottom, margin = 24.5.dp)
+                    }
+                    .size(70.dp)
+            ) {
+                Icon(
+                    painter = painterResource(R.drawable.btn_keyboard),
+                    contentDescription = stringResource(R.string.language_selector_expand_more),
+                    tint = Color.Unspecified
+                )
+            }
         }
     }
 }

--- a/app/main_screen/src/main/java/com/example/mainscreen/composables/InputView.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/composables/InputView.kt
@@ -53,7 +53,8 @@ fun inputViewTextStyle(
 fun InputView(
     modifier: Modifier = Modifier,
     state: MainScreenContract.InputViewState,
-    onClick: () -> Unit = {}
+    inputAreaOnClick: () -> Unit = {},
+    pasteButtonOnClick: () -> Unit = {}
 ) {
     var textFieldValue by remember { mutableStateOf(TextFieldValue("")) }
     val interactionSource = remember { MutableInteractionSource() }
@@ -63,7 +64,7 @@ fun InputView(
                     when (it) {
                         is PressInteraction.Release -> {
                             if (!state.isFocused) {
-                                onClick()
+                                inputAreaOnClick()
                             }
                         }
                     }
@@ -96,7 +97,8 @@ fun InputView(
                             .background(
                                 color = MaterialTheme.colorScheme.background,
                                 shape = shape
-                            ).fillMaxSize()
+                            )
+                            .fillMaxSize()
                     ) {
                         Text(
                             text = textFieldValue.text,
@@ -120,15 +122,16 @@ fun InputView(
 
         if (state.shouldShowSecondaryInputViews) {
             PasteButtonContainer(
-                pasteButtonContainerModifier = Modifier
+                modifier = Modifier
                     .constrainAs(pasteButton) {
                         top.linkTo(inputArea.top, margin = 70.dp)
                         start.linkTo(inputArea.start)
-                    }
+                    },
+                onClick = pasteButtonOnClick
             )
 
             IconButton(
-                onClick = { onClick() },
+                onClick = { inputAreaOnClick() },
                 modifier = Modifier
                     .constrainAs(keyboardButton) {
                         centerHorizontallyTo(inputArea)
@@ -160,13 +163,16 @@ fun pasteButtonColors() =
     ButtonDefaults.buttonColors(containerColor = MaterialTheme.colorScheme.tertiary)
 
 @Composable
-fun PasteButtonContainer(pasteButtonContainerModifier: Modifier) {
+fun PasteButtonContainer(
+    modifier: Modifier,
+    onClick: () -> Unit = {}
+) {
     Row(
-        modifier = pasteButtonContainerModifier,
+        modifier = modifier,
         verticalAlignment = Alignment.CenterVertically
     ) {
         Button(
-            onClick = { /*TODO*/ },
+            onClick = { onClick() },
             modifier = Modifier
                 .padding(start = 20.dp, top = 9.dp, end = 8.dp, bottom = 9.dp)
                 .wrapContentSize(),

--- a/app/main_screen/src/main/java/com/example/mainscreen/composables/InputView.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/composables/InputView.kt
@@ -1,5 +1,8 @@
 package com.example.mainscreen.composables
 
+import androidx.compose.foundation.interaction.Interaction
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
@@ -16,6 +19,7 @@ import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldColors
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -29,6 +33,7 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import com.example.mainscreen.R
+import kotlinx.coroutines.flow.collect
 
 private val roundingSize = 20.dp
 
@@ -49,6 +54,7 @@ fun inputViewTextStyle(
 // TODO: configure maximum vertical expansion
 @Composable
 fun InputView(
+    onClick: () -> Unit = {},
     textFieldColors: TextFieldColors = defaultTextFieldColors()
 ) {
     var textFieldValue by remember { mutableStateOf(TextFieldValue("")) }
@@ -75,7 +81,17 @@ fun InputView(
                     style = inputViewTextStyle(Color(0xFFA3ADB5)),
                     modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp)
                 )
-            }
+            },
+            interactionSource = remember { MutableInteractionSource() }
+                .also { source ->
+                    LaunchedEffect(source) {
+                        source.interactions.collect {
+                            when(it) {
+                                is PressInteraction.Release -> onClick()
+                            }
+                        }
+                    }
+                }
         )
 
         PasteButtonContainer(

--- a/app/main_screen/src/main/java/com/example/mainscreen/composables/InputView.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/composables/InputView.kt
@@ -1,6 +1,5 @@
 package com.example.mainscreen.composables
 
-import androidx.compose.foundation.interaction.Interaction
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
 import androidx.compose.foundation.layout.Row
@@ -33,7 +32,6 @@ import androidx.compose.ui.text.input.TextFieldValue
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import com.example.mainscreen.R
-import kotlinx.coroutines.flow.collect
 
 private val roundingSize = 20.dp
 

--- a/app/main_screen/src/main/java/com/example/mainscreen/composables/InputView.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/composables/InputView.kt
@@ -30,7 +30,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
@@ -81,6 +80,7 @@ fun InputView(
     ) {
         val (inputArea, pasteButton, keyboardButton) = createRefs()
 
+        // TODO: fix cursor
         BasicTextField(
             value = textFieldValue,
             onValueChange = { textFieldValue = it },
@@ -91,9 +91,7 @@ fun InputView(
                 .constrainAs(inputArea) {
                     centerHorizontallyTo(parent)
                 },
-            textStyle = inputViewTextStyle(),
             interactionSource = interactionSource,
-            cursorBrush = SolidColor(Color.Black)
         ) {
             TextFieldDefaults.DecorationBox(
                 value = textFieldValue.text,
@@ -106,7 +104,8 @@ fun InputView(
                     ) {
                         Text(
                             text = textFieldValue.text,
-                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp)
+                            modifier = Modifier.padding(horizontal = 20.dp, vertical = 12.dp),
+                            style = inputViewTextStyle()
                         )
                     }
                 },

--- a/app/main_screen/src/main/java/com/example/mainscreen/composables/InputView.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/composables/InputView.kt
@@ -1,20 +1,23 @@
 package com.example.mainscreen.composables
 
+import androidx.compose.foundation.background
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.PressInteraction
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.BasicTextField
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldColors
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
@@ -25,10 +28,13 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.SolidColor
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.TextFieldValue
+import androidx.compose.ui.text.input.VisualTransformation
 import androidx.compose.ui.unit.dp
 import androidx.constraintlayout.compose.ConstraintLayout
 import com.example.mainscreen.R
@@ -49,57 +55,83 @@ fun inputViewTextStyle(
     color = textColor
 )
 
+// TODO: propagate annotation
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun InputView(
-    isKeyboardButtonVisible: Boolean,
-    isPlaceholderVisible: Boolean,
+    areSecondaryViewsVisible: Boolean,
     onClick: () -> Unit = {},
     textFieldColors: TextFieldColors = defaultTextFieldColors()
 ) {
     var textFieldValue by remember { mutableStateOf(TextFieldValue("")) }
+    val interactionSource = remember { MutableInteractionSource() }
+        .also { source ->
+            LaunchedEffect(source) {
+                source.interactions.collect {
+                    when (it) {
+                        is PressInteraction.Release -> onClick()
+                    }
+                }
+            }
+        }
+    val shape = RoundedCornerShape(roundingSize, roundingSize, 0.dp, 0.dp)
 
     ConstraintLayout(
         modifier = Modifier.fillMaxSize()
     ) {
         val (inputArea, pasteButton, keyboardButton) = createRefs()
 
-        TextField(
+        BasicTextField(
             value = textFieldValue,
             onValueChange = { textFieldValue = it },
-            colors = textFieldColors,
             modifier = Modifier
                 .fillMaxSize()
+                .clip(shape)
+                .background(color = MaterialTheme.colorScheme.background)
                 .constrainAs(inputArea) {
                     centerHorizontallyTo(parent)
                 },
-            shape = RoundedCornerShape(roundingSize, roundingSize, 0.dp, 0.dp),
             textStyle = inputViewTextStyle(),
-            placeholder = {
-                if (isPlaceholderVisible) {
-                    Placeholder()
-                }
-            },
-            interactionSource = remember { MutableInteractionSource() }
-                .also { source ->
-                    LaunchedEffect(source) {
-                        source.interactions.collect {
-                            when(it) {
-                                is PressInteraction.Release -> onClick()
-                            }
-                        }
+            interactionSource = interactionSource,
+            cursorBrush = SolidColor(Color.Black)
+        ) {
+            TextFieldDefaults.DecorationBox(
+                value = textFieldValue.text,
+                innerTextField = {
+                    Row(
+                        modifier = Modifier.background(
+                            color = MaterialTheme.colorScheme.background,
+                            shape = shape
+                        ).fillMaxSize()
+                    ) {
+                        Text(
+                            text = textFieldValue.text,
+                            modifier = Modifier.padding(horizontal = 12.dp, vertical = 12.dp)
+                        )
                     }
-                }
-        )
+                },
+                enabled = true,
+                singleLine = false,
+                placeholder = {
+                    if (areSecondaryViewsVisible) {
+                        Placeholder()
+                    }
+                },
+                visualTransformation = VisualTransformation.None,
+                interactionSource = interactionSource,
+                contentPadding = PaddingValues(0.dp)
+            )
+        }
 
-        PasteButtonContainer(
-            pasteButtonContainerModifier = Modifier
-                .constrainAs(pasteButton) {
-                    top.linkTo(inputArea.top, margin = 70.dp)
-                    start.linkTo(inputArea.start)
-                }
-        )
+        if (areSecondaryViewsVisible) {
+            PasteButtonContainer(
+                pasteButtonContainerModifier = Modifier
+                    .constrainAs(pasteButton) {
+                        top.linkTo(inputArea.top, margin = 70.dp)
+                        start.linkTo(inputArea.start)
+                    }
+            )
 
-        if (isKeyboardButtonVisible) {
             IconButton(
                 onClick = { onClick() },
                 modifier = Modifier
@@ -124,7 +156,7 @@ fun Placeholder() {
     Text(
         text = stringResource(R.string.input_view_hint),
         style = inputViewTextStyle(Color(0xFFA3ADB5)),
-        modifier = Modifier.padding(horizontal = 8.dp, vertical = 8.dp)
+        modifier = Modifier.padding(horizontal = 20.dp, vertical = 18.dp)
     )
 }
 
@@ -142,8 +174,7 @@ fun PasteButtonContainer(pasteButtonContainerModifier: Modifier) {
             onClick = { /*TODO*/ },
             modifier = Modifier
                 .padding(start = 20.dp, top = 9.dp, end = 8.dp, bottom = 9.dp)
-                .wrapContentSize()
-            ,
+                .wrapContentSize(),
             colors = pasteButtonColors()
         ) {
             Text(

--- a/app/main_screen/src/main/java/com/example/mainscreen/composables/LanguageSelectorRow.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/composables/LanguageSelectorRow.kt
@@ -13,15 +13,15 @@ import com.example.mainscreen.R
 
 @Composable
 fun LanguageSelectorRow(
+    modifier: Modifier,
     sourceState: MainScreenContract.LanguageSelectorState,
     destinationState: MainScreenContract.LanguageSelectorState,
-    rowModifier: Modifier
 ) {
     val iconPainter = painterResource(R.drawable.change_icon)
 
     Row(
         verticalAlignment = Alignment.CenterVertically,
-        modifier = rowModifier
+        modifier = modifier
     ) {
         LanguageSelector(state = sourceState)
 

--- a/app/main_screen/src/main/java/com/example/mainscreen/composables/MainScreen.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/composables/MainScreen.kt
@@ -33,6 +33,7 @@ fun MainScreen(
 
         InputView(
             isKeyboardButtonVisible = state.shouldShowKeyboardButton,
+            isPlaceholderVisible = state.shouldShowPlaceholder,
             onClick = { onEventSent(MainScreenContract.Event.InputViewClick) }
         )
     }

--- a/app/main_screen/src/main/java/com/example/mainscreen/composables/MainScreen.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/composables/MainScreen.kt
@@ -31,6 +31,9 @@ fun MainScreen(
             rowModifier = Modifier.padding(selectorsPaddingValues)
         )
 
-        InputView()
+        InputView(
+            isKeyboardButtonVisible = state.shouldShowKeyboardButton,
+            onClick = { onEventSent(MainScreenContract.Event.InputViewClick) }
+        )
     }
 }

--- a/app/main_screen/src/main/java/com/example/mainscreen/composables/MainScreen.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/composables/MainScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalClipboardManager
 import androidx.compose.ui.unit.dp
 import com.example.mainscreen.MainScreenContract
 import kotlinx.coroutines.flow.Flow
@@ -20,6 +21,8 @@ fun MainScreen(
     Column(
         horizontalAlignment = Alignment.CenterHorizontally,
     ) {
+        val clipboardManager = LocalClipboardManager.current.getText()
+
         AnimatedVisibility(visible = state.shouldShowPreTranslateImage) {
             MainScreenImage()
         }
@@ -35,7 +38,11 @@ fun MainScreen(
         InputView(
             modifier = Modifier.weight(1f),
             state = state.inputViewState,
-            onClick = { onEventSent(MainScreenContract.Event.InputViewClick) }
+            inputAreaOnClick = { onEventSent(MainScreenContract.Event.InputViewClick) },
+            pasteButtonOnClick = {
+                val text = clipboardManager?.text
+                onEventSent(MainScreenContract.Event.PasteButtonClick(text))
+            }
         )
     }
 }

--- a/app/main_screen/src/main/java/com/example/mainscreen/composables/MainScreen.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/composables/MainScreen.kt
@@ -19,7 +19,9 @@ fun MainScreen(
     Column(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
-        MainScreenImage()
+        if (state.shouldShowPreTranslateImage) {
+            MainScreenImage()
+        }
 
         val selectorsPaddingValues = PaddingValues(0.dp, 0.dp, 0.dp, 14.dp)
 

--- a/app/main_screen/src/main/java/com/example/mainscreen/composables/MainScreen.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/composables/MainScreen.kt
@@ -32,8 +32,7 @@ fun MainScreen(
         )
 
         InputView(
-            isKeyboardButtonVisible = state.shouldShowKeyboardButton,
-            isPlaceholderVisible = state.shouldShowPlaceholder,
+            areSecondaryViewsVisible = state.shouldShowSecondaryInputViews,
             onClick = { onEventSent(MainScreenContract.Event.InputViewClick) }
         )
     }

--- a/app/main_screen/src/main/java/com/example/mainscreen/composables/MainScreen.kt
+++ b/app/main_screen/src/main/java/com/example/mainscreen/composables/MainScreen.kt
@@ -1,5 +1,6 @@
 package com.example.mainscreen.composables
 
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
@@ -17,22 +18,23 @@ fun MainScreen(
     onEventSent: (event: MainScreenContract.Event) -> Unit,
 ) {
     Column(
-        horizontalAlignment = Alignment.CenterHorizontally
+        horizontalAlignment = Alignment.CenterHorizontally,
     ) {
-        if (state.shouldShowPreTranslateImage) {
+        AnimatedVisibility(visible = state.shouldShowPreTranslateImage) {
             MainScreenImage()
         }
 
         val selectorsPaddingValues = PaddingValues(0.dp, 0.dp, 0.dp, 14.dp)
 
         LanguageSelectorRow(
+            modifier = Modifier.padding(selectorsPaddingValues),
             sourceState = state.sourceSelectorState,
-            destinationState = state.destinationSelectorState,
-            rowModifier = Modifier.padding(selectorsPaddingValues)
+            destinationState = state.destinationSelectorState
         )
 
         InputView(
-            areSecondaryViewsVisible = state.shouldShowSecondaryInputViews,
+            modifier = Modifier.weight(1f),
+            state = state.inputViewState,
             onClick = { onEventSent(MainScreenContract.Event.InputViewClick) }
         )
     }


### PR DESCRIPTION
Done:
- Reworked contract to control views visibility
- Added animated visibility change of pre-translate image
- Rewritten InputView, used BasicTextField underneath 

[example.webm](https://github.com/vamelchenia/nerd-translator/assets/23167154/39321663-ede2-45b8-8d4c-547e1d9db7f2)
